### PR TITLE
fixed: Secure each microservice with oauth #13

### DIFF
--- a/Auth/MicroMed.IdentityServer/Program.cs
+++ b/Auth/MicroMed.IdentityServer/Program.cs
@@ -23,6 +23,7 @@ builder.Services
     .AddIdentityServer()
     .AddInMemoryIdentityResources(Config.IdentityResources)
     .AddInMemoryApiScopes(Config.ApiScopes)
+    .AddInMemoryApiResources(Config.ApiResources)
     .AddInMemoryClients(Config.BuildClients(builder.Configuration.GetSection("Clients").Get<ClientConfiguration[]>()!))
     .AddAspNetIdentity<IdentityUser>();
 
@@ -146,7 +147,26 @@ internal static class Config
         [
             new ApiScope("admin"),
             new ApiScope("doctor"),
-            new ApiScope("patient")
+            new ApiScope("patient"),
+            new ApiScope("clinics.api", "Clinics API"),
+            new ApiScope("doctors.api", "Doctors API"),
+            new ApiScope("timetable.api", "Timetable API")
+        ];
+
+    public static IEnumerable<ApiResource> ApiResources =>
+        [
+            new ApiResource("clinics.api", "Clinics API")
+            {
+                Scopes = { "clinics.api" }
+            },
+            new ApiResource("doctors.api", "Doctors API")
+            {
+                Scopes = { "doctors.api" }
+            },
+            new ApiResource("timetable.api", "Timetable API")
+            {
+                Scopes = { "timetable.api" }
+            }
         ];
 
     public static IEnumerable<Client> BuildClients(ClientConfiguration[] clientsConfiguration) =>
@@ -158,13 +178,28 @@ internal static class Config
             AllowedGrantTypes = GrantTypes.Code,
             RedirectUris = { $"{clientConfig.BaseUrl}/signin-oidc" },
             PostLogoutRedirectUris = { $"{clientConfig.BaseUrl}signout-callback-oidc" },
-            AllowedScopes =
-                [
-                    IdentityServerConstants.StandardScopes.OpenId,
-                    IdentityServerConstants.StandardScopes.Profile,
-                    clientConfig.Scope
-                ]
-        });        
+            AllowedScopes = GetAllowedScopes(clientConfig)
+        });
+
+    private static List<string> GetAllowedScopes(ClientConfiguration clientConfig)
+    {
+        var scopes = new List<string>
+        {
+            IdentityServerConstants.StandardScopes.OpenId,
+            IdentityServerConstants.StandardScopes.Profile,
+            clientConfig.Scope
+        };
+
+        // Admin portal gets access to all APIs
+        if (clientConfig.Name == "AdminPortal")
+        {
+            scopes.Add("clinics.api");
+            scopes.Add("doctors.api");
+            scopes.Add("timetable.api");
+        }
+
+        return scopes;
+    }
 }
 
 internal record ClientConfiguration(string Name, string Scope, string BaseUrl, string Secret);

--- a/BFF/MicroMed.BFF.Admin/ClinicsClient.cs
+++ b/BFF/MicroMed.BFF.Admin/ClinicsClient.cs
@@ -1,21 +1,47 @@
 ﻿using Clinics.Contracts.Dto;
+using Microsoft.AspNetCore.Authentication;
+using System.Net.Http.Headers;
 
 namespace MicroMed.BFF.Admin;
 
 public class ClinicsClient
 {
     private readonly string _clinicsServiceUrl;
-    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public ClinicsClient(string clinicsServiceUrl, IHttpClientFactory httpClientFactory)
+    public ClinicsClient(string clinicsServiceUrl, IHttpClientFactory httpClientFactory, IHttpContextAccessor httpContextAccessor)
     {
         _clinicsServiceUrl = clinicsServiceUrl;
-        _httpClient = httpClientFactory.CreateClient();
+        _httpClientFactory = httpClientFactory;
+        _httpContextAccessor = httpContextAccessor;
     }
 
-    public async Task<GetClinicsResponse> GetClinicsAsync(CancellationToken cancellationToken) 
-        => (await _httpClient.GetFromJsonAsync<GetClinicsResponse>(_clinicsServiceUrl + "/Clinics", cancellationToken))!;
+    private async Task<HttpClient> CreateAuthenticatedClientAsync()
+    {
+        var httpClient = _httpClientFactory.CreateClient();
+        
+        if (_httpContextAccessor.HttpContext != null)
+        {
+            var accessToken = await _httpContextAccessor.HttpContext.GetTokenAsync("access_token");
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            }
+        }
+        
+        return httpClient;
+    }
 
-    public Task AddClinicAsync(AddClinicRequest request, CancellationToken cancellationToken = default) 
-        => _httpClient.PostAsJsonAsync(_clinicsServiceUrl + "/Clinics", request, cancellationToken);
+    public async Task<GetClinicsResponse> GetClinicsAsync(CancellationToken cancellationToken)
+    {
+        var httpClient = await CreateAuthenticatedClientAsync();
+        return (await httpClient.GetFromJsonAsync<GetClinicsResponse>(_clinicsServiceUrl + "/Clinics", cancellationToken))!;
+    }
+
+    public async Task AddClinicAsync(AddClinicRequest request, CancellationToken cancellationToken = default)
+    {
+        var httpClient = await CreateAuthenticatedClientAsync();
+        await httpClient.PostAsJsonAsync(_clinicsServiceUrl + "/Clinics", request, cancellationToken);
+    }
 }

--- a/BFF/MicroMed.BFF.Admin/Program.cs
+++ b/BFF/MicroMed.BFF.Admin/Program.cs
@@ -12,6 +12,7 @@ builder.Services
     .AddEndpointsApiExplorer()
     .AddOpenApi()
     .AddAuthorization()
+    .AddHttpContextAccessor()
     .AddAuthentication(options =>
     {
         options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -32,6 +33,9 @@ builder.Services
         options.ResponseMode = "query";
         options.UsePkce = true;
         options.Scope.Add("admin");
+        options.Scope.Add("clinics.api");
+        options.Scope.Add("doctors.api");
+        options.Scope.Add("timetable.api");
         options.SaveTokens = true;
         options.GetClaimsFromUserInfoEndpoint = true;
         options.RequireHttpsMetadata = false;
@@ -53,8 +57,11 @@ builder.Services.AddSyncfusionBlazor();
 
 var serviceUrls = builder.Configuration.GetSection("Services").Get<ServiceUrls>()!;
 
-builder.Services.AddSingleton(services
-    => new ClinicsClient(serviceUrls.Clinics, services.GetRequiredService<IHttpClientFactory>()));
+builder.Services.AddScoped(services
+    => new ClinicsClient(
+        serviceUrls.Clinics, 
+        services.GetRequiredService<IHttpClientFactory>(),
+        services.GetRequiredService<IHttpContextAccessor>()));
 builder.Services.AddHttpClient();
 
 var app = builder.Build();

--- a/Services/Clinics/Clinics.API/Clinics.API.csproj
+++ b/Services/Clinics/Clinics.API/Clinics.API.csproj
@@ -11,6 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
 	</ItemGroup>
 

--- a/Services/Clinics/Clinics.API/Endpoints.cs
+++ b/Services/Clinics/Clinics.API/Endpoints.cs
@@ -10,26 +10,27 @@ public static class Endpoints
     public static void MapEndpoints(this WebApplication app)
     {
         app.MapGet("Clinics", (IMediator mediator, CancellationToken cancellationToken)
-            => mediator.Send(new ClinicsQuery(), cancellationToken));
+            => mediator.Send(new ClinicsQuery(), cancellationToken))
+            .RequireAuthorization();
 
         app.MapPost("Clinics", async (IMediator mediator, AddClinicRequest request, CancellationToken cancellationToken) =>
         {
             var result = await mediator.Send(new AddClinicCommand(request), cancellationToken);
             return Results.Ok(new AddClinicResponse(result)); // todo change to Created
-        });
+        }).RequireAuthorization();
 
         app.MapPut("Clinics/{clinicId:int}", async (IMediator mediator, int clinicId, UpdateClinicRequest request) =>
         {
             await mediator.Send(new UpdateClinicCommand(clinicId, request));
             return Results.NoContent();
-        });
+        }).RequireAuthorization();
 
         app.MapPost("Clinics/{clinicId:int}/Surgeries",
             async (IMediator mediator, int clinicId, AddSurgeryRequest request, CancellationToken cancellationToken) =>
             {
                 var result = await mediator.Send(new AddSurgeryCommand(clinicId, request), cancellationToken);
                 return Results.Ok(new AddSurgeryResponse(result)); // todo change to Created
-            });
+            }).RequireAuthorization();
 
         app.MapPut("Clinics/{clinicId:int}/Surgeries/{surgeryId:int}",
             async (IMediator mediator, int clinicId, int surgeryId, UpdateSurgeryRequest request,
@@ -37,17 +38,21 @@ public static class Endpoints
             {
                 await mediator.Send(new UpdateSurgeryCommand(clinicId, surgeryId, request), cancellationToken);
                 return Results.NoContent();
-            });
+            }).RequireAuthorization();
 
         app.MapDelete("Clinics/{clinicId:int}/Surgeries/{surgeryId:int}",
             async (IMediator mediator, int clinicId, int surgeryId, CancellationToken cancellationToken) =>
             {
                 await mediator.Send(new RemoveSurgeryCommand(clinicId, surgeryId), cancellationToken);
                 return Results.NoContent();
-            });
+            }).RequireAuthorization();
 
         app.MapPost("SurgeryEquipment",
             async (IMediator mediator, AddSurgeryEquipmentRequest request, CancellationToken cancellationToken) =>
+            {
+                var result = await mediator.Send(new AddSurgeryEquipmentCommand(request), cancellationToken);
+                return Results.Ok(new AddSurgeryEquipmentResponse(result)); // todo change to Created
+            }).RequireAuthorization();
             {
                 var result = await mediator.Send(new AddSurgeryEquipmentCommand(request), cancellationToken);
                 return Results.Ok(new AddSurgeryEquipmentResponse(result)); // todo change to Created

--- a/Services/Clinics/Clinics.API/Program.cs
+++ b/Services/Clinics/Clinics.API/Program.cs
@@ -2,6 +2,7 @@ using Clinics.API;
 using Clinics.Infrastructure;
 using Clinics.Infrastructure.Repositories;
 using Clinics.Services.Repositories;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Shared.API;
 using Shared.Services;
@@ -17,6 +18,23 @@ builder.Services
     })
     .AddEndpointsApiExplorer()
     .AddOpenApi()
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        var authSettings = builder.Configuration.GetSection("Authentication");
+        options.Authority = authSettings["Authority"];
+        options.Audience = "clinics.api";
+        options.RequireHttpsMetadata = false;
+        options.TokenValidationParameters = new()
+        {
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidateLifetime = true
+        };
+    });
+
+builder.Services
+    .AddAuthorization()
     .AddScoped<IClinicRepository, ClinicRepository>()
     .AddScoped<IEquipmentRepository, EquipmentRepository>()
     .AddScoped<IUnitOfWork>(services => services.GetRequiredService<ClinicsDbContext>())
@@ -40,6 +58,9 @@ if (app.Environment.IsDevelopment())
         await dbContext.Database.EnsureCreatedAsync();
     }
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapEndpoints();
 

--- a/Services/Clinics/Clinics.API/appsettings.Development.json
+++ b/Services/Clinics/Clinics.API/appsettings.Development.json
@@ -8,6 +8,9 @@
   "ConnectionStrings": {
     "SqlServer": "Data Source=host.docker.internal,1435;Database=MicroMed_Clinics;User ID=sa;Password=P@ssword1;Encrypt=False;"
   },
+  "Authentication": {
+    "Authority": "http://host.docker.internal:5000"
+  },
   "RabbitMQ": {
     "host": "host.docker.internal",
     "virtualHost": "/",

--- a/Services/Doctors/Doctors.API/Doctors.API.csproj
+++ b/Services/Doctors/Doctors.API/Doctors.API.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
   </ItemGroup>
 

--- a/Services/Doctors/Doctors.API/Endpoints.cs
+++ b/Services/Doctors/Doctors.API/Endpoints.cs
@@ -12,6 +12,6 @@ public static class Endpoints
         {
             var result = await mediator.Send(new RegisterDoctorCommand(dto), cancellationToken);
             return Results.Ok(new RegisterDoctorResponse(result)); // todo: change to Created
-        });
+        }).RequireAuthorization();
     }
 }

--- a/Services/Doctors/Doctors.API/Program.cs
+++ b/Services/Doctors/Doctors.API/Program.cs
@@ -1,6 +1,7 @@
 using Doctors.API;
 using Doctors.Infrastructure;
 using Doctors.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Shared.API;
 using Shared.Services;
@@ -19,6 +20,23 @@ builder.Services
     .AddMassTransit<DoctorsDbContext>(builder.Configuration)
     .AddEndpointsApiExplorer()
     .AddOpenApi()
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        var authSettings = builder.Configuration.GetSection("Authentication");
+        options.Authority = authSettings["Authority"];
+        options.Audience = "doctors.api";
+        options.RequireHttpsMetadata = false;
+        options.TokenValidationParameters = new()
+        {
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidateLifetime = true
+        };
+    });
+
+builder.Services
+    .AddAuthorization()
     .AddSqlConnectionProvider(builder.Configuration);
 
 var app = builder.Build();
@@ -38,6 +56,9 @@ if (app.Environment.IsDevelopment())
         await dbContext.Database.EnsureCreatedAsync();
     }
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapEndpoints();
 

--- a/Services/Doctors/Doctors.API/appsettings.Development.json
+++ b/Services/Doctors/Doctors.API/appsettings.Development.json
@@ -8,6 +8,9 @@
   "ConnectionStrings": {
     "SqlServer": "Data Source=host.docker.internal,1435;Database=MicroMed_Doctors;User ID=sa;Password=P@ssword1;Encrypt=False;"
   },
+  "Authentication": {
+    "Authority": "http://host.docker.internal:5000"
+  },
   "RabbitMQ": {
     "host": "host.docker.internal",
     "virtualHost": "/",

--- a/Services/Timetable/Timetable.API/Program.cs
+++ b/Services/Timetable/Timetable.API/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Shared.API;
 using Shared.Services;
@@ -16,6 +17,23 @@ builder.Services
         options.UseSqlServer(builder.Configuration.GetConnectionString("SqlServer"));
         options.EnableSensitiveDataLogging();
     })
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        var authSettings = builder.Configuration.GetSection("Authentication");
+        options.Authority = authSettings["Authority"];
+        options.Audience = "timetable.api";
+        options.RequireHttpsMetadata = false;
+        options.TokenValidationParameters = new()
+        {
+            ValidateAudience = true,
+            ValidateIssuer = true,
+            ValidateLifetime = true
+        };
+    });
+
+builder.Services
+    .AddAuthorization()
     .AddScoped<ISurgeryRepository, SurgeryRepository>()
     .AddScoped<IDoctorsRepository, DoctorsRepository>()
     .AddScoped<IAppointmentRepository, AppointmentRepository>()
@@ -39,5 +57,8 @@ if (app.Environment.IsDevelopment())
         await dbContext.Database.EnsureCreatedAsync();
     }
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.Run();

--- a/Services/Timetable/Timetable.API/Timetable.API.csproj
+++ b/Services/Timetable/Timetable.API/Timetable.API.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />

--- a/Services/Timetable/Timetable.API/appsettings.Development.json
+++ b/Services/Timetable/Timetable.API/appsettings.Development.json
@@ -8,6 +8,9 @@
   "ConnectionStrings": {
     "SqlServer": "Data Source=host.docker.internal,1435;Database=MicroMed_Timetable;User ID=sa;Password=P@ssword1;Encrypt=False;"
   },
+  "Authentication": {
+    "Authority": "http://host.docker.internal:5000"
+  },
   "RabbitMQ": {
     "host": "host.docker.internal",
     "virtualHost": "/",


### PR DESCRIPTION
# Secure Each Microservice with OAuth #13

## Summary

Implemented OAuth 2.0 authentication across all MicroMed microservices using JWT Bearer tokens and Duende IdentityServer.

## Changes

### IdentityServer

- Added API resources and scopes: `clinics.api`, `doctors.api`, `timetable.api`
- Updated AdminPortal client to include all API scopes

### Microservices (Clinics, Doctors, Timetable APIs)

- Added `Microsoft.AspNetCore.Authentication.JwtBearer` package (v10.0.0)
- Configured JWT authentication with IdentityServer as authority
- Added `UseAuthentication()` and `UseAuthorization()` middleware
- All endpoints now require authorization
- Added `Authentication:Authority` setting in appsettings.Development.json

### BFF Admin Portal

- Added API scopes to OpenID Connect configuration
- Updated `ClinicsClient` to retrieve and attach JWT access tokens to requests
- Added `IHttpContextAccessor` for token management
- Changed `ClinicsClient` from Singleton to Scoped

## Security Features

✅ Token validation (audience, issuer, lifetime, signature)  
✅ All API endpoints require valid JWT tokens  
✅ Centralized authentication through IdentityServer  
✅ Automatic token propagation from BFF to APIs

## Testing

```bash
cd docker-compose
docker-compose up --build
```

- Access Admin Portal at `http://localhost:5001`
- Login with admin credentials
- API calls automatically include JWT tokens

## Production Considerations

- [ ] Enable HTTPS (`RequireHttpsMetadata = true`)
- [ ] Use strong client secrets
- [ ] Implement role/scope-based authorization
- [ ] Add refresh token support
- [ ] Enable authentication logging

---

**Status**: ✅ Completed - No compilation errors
